### PR TITLE
Reference WebSocket closing codes.

### DIFF
--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -207,7 +207,7 @@ Full details about the Ready event is in the [Gateway events documentation](#DOC
 
 Gateway disconnects happen for a variety of reasons, and may be initiated by Discord or by your app.
 
-In the event of Discord initiating a disconnect, you may run into generalised WebSocket closing codes. A server-initated closure will most commonly be found from [these closing codes.](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/gateway-gateway-server-closing-codes)
+In the event of Discord initiating a disconnect, you may run into generalised WebSocket closing codes. A server-initated closure will occur when the WebSocket protocol initiates a `CLOSING` frame-based action.
 
 #### Handling a Disconnect
 

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -207,6 +207,8 @@ Full details about the Ready event is in the [Gateway events documentation](#DOC
 
 Gateway disconnects happen for a variety of reasons, and may be initiated by Discord or by your app.
 
+In the event of Discord initiating a disconnect, you may run into generalised WebSocket closing codes. A server-initated closure will most commonly be found from [these closing codes.](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/gateway-gateway-server-closing-codes)
+
 #### Handling a Disconnect
 
 Due to Discord's architecture, disconnects are a semi-regular event and should be expected and handled. When your app encounters a disconnect, it will typically be sent a [close code](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/gateway-gateway-close-event-codes) which can be used to determine whether you can reconnect and [Resume](#DOCS_TOPICS_GATEWAY/resuming) the session, or whether you have to start over and re-Identify.

--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -41,18 +41,6 @@ In order to prevent broken reconnect loops, you should consider some close codes
 | 4013 | Invalid intent(s)     | You sent an invalid intent for a [Gateway Intent](#DOCS_TOPICS_GATEWAY/gateway-intents). You may have incorrectly calculated the bitwise value.                                                                                  | false     |
 | 4014 | Disallowed intent(s)  | You sent a disallowed intent for a [Gateway Intent](#DOCS_TOPICS_GATEWAY/gateway-intents). You may have tried to specify an intent that you [have not enabled or are not approved for](#DOCS_TOPICS_GATEWAY/privileged-intents). | false     |
 
-###### Gateway Server Closing Codes
-
-Server-initated closures by the Gateway are a semi-regular event as part of disconnects, and should be properly tracked. These closing codes are handled by most Discord libraries, but can be a hassle for providing persistent client connections if left unchecked.
-Some enumerator codes may be left out due to either never sending, or considered as generally rare closes.
-
-| Code | Description           | Explanation                                                                                                                                                                                                                      | Reconnect |
-|------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
-| 1000 | Normal closure        | The server or client of the connection failed to process data, resulting in a safe close.                                                                                                                                        | true      |
-| 1006 | Abnormal closure      | A disconnect was performed without properly sending a `CLOSING` frame.                                                                                                                                                           | true      |
-| 1008 | Policy violation      | Improper data was sent as a message to a [payload](#DOCS_TOPICS_GATEWAY/sending-events) leading to an immediate disconnect. This will rarely show compared to `4002`.                                                            | true      |
-| 1011 | Internal error        | An internal error resulted, usually in parallel to a policy violation. Try reconnecting?                                                                                                                                         | true      |
-
 ## Voice
 
 Our voice gateways have their own set of opcodes and close codes.

--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -24,7 +24,6 @@ All gateway events in Discord are tagged with an opcode that denotes the payload
 
 In order to prevent broken reconnect loops, you should consider some close codes as a signal to stop reconnecting. This can be because your token expired, or your identification is invalid. This table explains what the application defined close codes for the gateway are, and which close codes you should not attempt to reconnect.
 
-
 | Code | Description           | Explanation                                                                                                                                                                                                                      | Reconnect |
 |------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
 | 4000 | Unknown error         | We're not sure what went wrong. Try reconnecting?                                                                                                                                                                                | true      |
@@ -41,6 +40,18 @@ In order to prevent broken reconnect loops, you should consider some close codes
 | 4012 | Invalid API version   | You sent an invalid version for the gateway.                                                                                                                                                                                     | false     |
 | 4013 | Invalid intent(s)     | You sent an invalid intent for a [Gateway Intent](#DOCS_TOPICS_GATEWAY/gateway-intents). You may have incorrectly calculated the bitwise value.                                                                                  | false     |
 | 4014 | Disallowed intent(s)  | You sent a disallowed intent for a [Gateway Intent](#DOCS_TOPICS_GATEWAY/gateway-intents). You may have tried to specify an intent that you [have not enabled or are not approved for](#DOCS_TOPICS_GATEWAY/privileged-intents). | false     |
+
+###### Gateway Server Closing Codes
+
+Server-initated closures by the Gateway are a semi-regular event as part of disconnects, and should be properly tracked. These closing codes are handled by most Discord libraries, but can be a hassle for providing persistent client connections if left unchecked.
+Some enumerator codes may be left out due to either never sending, or considered as generally rare closes.
+
+| Code | Description           | Explanation                                                                                                                                                                                                                      | Reconnect |
+|------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| 1000 | Normal closure        | The server or client of the connection failed to process data, resulting in a safe close.                                                                                                                                        | true      |
+| 1006 | Abnormal closure      | A disconnect was performed without properly sending a `CLOSING` frame.                                                                                                                                                           | true      |
+| 1008 | Policy violation      | Improper data was sent as a message to a [payload](#DOCS_TOPICS_GATEWAY/sending-events) leading to an immediate disconnect. This will rarely show compared to `4002`.                                                            | true      |
+| 1011 | Internal error        | An internal error resulted, usually in parallel to a policy violation. Try reconnecting?                                                                                                                                         | true      |
 
 ## Voice
 


### PR DESCRIPTION
## Introduction

Discord's Gateway documentation update is giving more light to disconnects and how to resume/reconnect from them. While `4xxx` codes are commonly seen from client-initiated closures and incorrect data passage, server-initiated closures are not noted while being semi-regular in part of the disconnection process.

## Motive

Common WebSocket closing codes, such as `1006` and `1011` are *extremely* frequent on Discord. I'm unsure whether Discord intentionally send these, or if the latter (Internal Error) comes as a result of the WebSocket server making mishaps.

Being unaware about general closes is detrimental to keeping a persistent connection. It's not necessarily the fault of the developer, but rather ignorance and being misinformed about their presence in the connection lifecycle. They're very annoying to track as edge cases, and as a result should be handled as a safe measure.

There's no good way to generically reference these, so it is in my interests out of good spirit to note them. The goal of this proposal is to bring more light to developers willingly implementing their own Gateway solutions, educating them about their existence and how they can be handled.

All of the closing codes aforementioned are reconnectable so-as-long a `RECONNECT` event has been sent beforehand with the inner boolean value as `true`. Otherwise, they must be discarded connections. (?)

## Changes
- Added `Gateway Server Closing Codes table`
  - All of these are able to be resumed on the basis* of an already consistent connection. (Such as idling)
  - These codes only cover the most common general closures by [RFC 6455.](https://www.rfc-editor.org/rfc/rfc6455#section-7.2)
  - A notation was added to this header section describing above fact. Maybe turning this into an admonition is better?
- Referenced in `Disconnecting` about server-initiated closures being existent, and as common as a client-initiated closure.

## Caveats
With these being documented, if the proposal is accepted, users may want a whole list of closing codes to be documented. This is the biggest downside to considering this, because Discord documentation should (obviously) cater to the service and not what it runs off of. Documenting from RFC 6455 should be taken with a grain of salt, it's both a good and bad thing that we're making reference of it without getting too knees-deep.

Another thing to consider is "what if Discord's `4xxx` closing codes overlap with WebSocket closing codes?" This is somewhat already seen with `Policy violation`/`1008` closes. Would it be worth mentioning it, or purely documenting the explanation as to what the closing code represents, instead of its *significance* to the Gateway lifecycle?